### PR TITLE
Fix version prefix in specs [WIP]

### DIFF
--- a/lib/rocket_pants/controller/versioning.rb
+++ b/lib/rocket_pants/controller/versioning.rb
@@ -22,7 +22,7 @@ module RocketPants
     def version
       if !instance_variable_defined?(:@version)
         @version = begin
-          version = extract_version_string_with_prefix params[:version], request.symbolized_path_parameters[:rp_prefix]
+          version = remove_prefix_from_version params[:version]
           version.presence && Integer(version)
         rescue ArgumentError
           nil
@@ -35,17 +35,10 @@ module RocketPants
       error! :invalid_version unless version.present? && _version_range.include?(version)
     end
 
-    def extract_version_string_with_prefix(version, prefix)
-      if version && prefix.is_a?(Hash)
-        # We need to strip the text from the prefix.
-        prefix_regexp = /^#{prefix[:text]}/
-        version = version.to_s
-        if prefix[:required] && version !~ prefix_regexp
-          raise ArgumentError, "You required the route version prefix #{prefix[:text]}, but not was given."
-        end
-        version.gsub prefix_regexp, ''
+    def remove_prefix_from_version(version)
+      if version
+        version.gsub /[^0-9]+/, ''
       else
-        # Otherwise, return it intact.
         version
       end
     end

--- a/lib/rocket_pants/routing.rb
+++ b/lib/rocket_pants/routing.rb
@@ -9,22 +9,22 @@ module RocketPants
     def rocket_pants(options = {}, &blk)
       versions = extract_rocket_pants_versions options
 
-      defaults = {:format => 'json'}
-
       if (optional_prefix = options.delete(:allow_prefix))
         versions.map! { |v| "#{optional_prefix}?#{v}" }
-        defaults[:rp_prefix] = {:text => optional_prefix.to_s, :required => false}
       elsif (required_prefix = options.delete(:require_prefix))
         versions.map! { |v| "#{required_prefix}#{v}" }
-        defaults[:rp_prefix] = {:text => required_prefix.to_s, :required => true}
       end
+
       versions_regexp = /(#{versions.uniq.join("|")})/
+
       raise ArgumentError, 'please provide atleast one version' if versions.empty?
+
       options = options.deep_merge({
         :constraints => {:version => versions_regexp},
         :path        => ':version',
-        :defaults    => defaults
+        :defaults    => {:format => 'json'}
       })
+
       scope options, &blk
     end
     alias api rocket_pants

--- a/lib/rocket_pants/rspec_matchers.rb
+++ b/lib/rocket_pants/rspec_matchers.rb
@@ -97,7 +97,7 @@ module RocketPants
       end
 
       failure_message_for_should do |response|
-        message = "expected api to have exposed #{normalised_response.inspect}, got #{response.parsed_body} instead."
+        message = "expected api to have exposed #{args.first.inspect}, got #{response.parsed_body} instead."
         message << "\n\nDiff: #{RSpecMatchers.differ.diff_as_object(@decoded, normalised_response)}"
         message
       end

--- a/lib/rocket_pants/rspec_matchers.rb
+++ b/lib/rocket_pants/rspec_matchers.rb
@@ -97,7 +97,7 @@ module RocketPants
       end
 
       failure_message_for_should do |response|
-        message = "expected api to have exposed #{normalised_response.inspect}, got #{@decoded.inspect} instead."
+        message = "expected api to have exposed #{normalised_response.inspect}, got #{response.parsed_body} instead."
         message << "\n\nDiff: #{RSpecMatchers.differ.diff_as_object(@decoded, normalised_response)}"
         message
       end

--- a/lib/rocket_pants/rspec_matchers.rb
+++ b/lib/rocket_pants/rspec_matchers.rb
@@ -90,6 +90,7 @@ module RocketPants
 
     matcher :have_exposed do |*args|
       normalised_response = RSpecMatchers.normalise_response(*args)
+      expected_data = args.first
 
       match do |response|
         @decoded = RSpecMatchers.normalise_urls(response.parsed_body["response"])
@@ -97,13 +98,13 @@ module RocketPants
       end
 
       failure_message_for_should do |response|
-        message = "expected api to have exposed #{args.first.inspect}, got #{response.parsed_body} instead."
-        message << "\n\nDiff: #{RSpecMatchers.differ.diff_as_object(@decoded, normalised_response)}"
+        message = "expected api to have exposed #{expected_data.inspect}, got #{response.parsed_body} instead."
+        message << "\n\nDiff: #{RSpecMatchers.differ.diff_as_object(expected_data, response.parsed_body)}"
         message
       end
 
       failure_message_for_should_not do |response|
-        "expected api to not have exposed #{normalised_response.inspect}"
+        "expected api to not have exposed #{expected_data.inspect}"
       end
 
     end

--- a/lib/rocket_pants/test_helper.rb
+++ b/lib/rocket_pants/test_helper.rb
@@ -75,20 +75,22 @@ module RocketPants
     protected
 
     # Like process, but automatically adds the api version.
-    def process(action, http_method = 'GET', *args)
-      # Rails 4 changes the method signature. In rails 3, http_method is actually
-      # the paramters.
-      if http_method.kind_of?(String)
-        parameters, session, flash = args
+    def process(action, *args)
+      # Rails 4: def process(action, http_method, parameters, session, flash)
+      # Rails 3: def process(action, parameters, session, flash, http_method)
+      if args.first.kind_of?(String)
+        http_method, parameters, session, flash = args
       else
-        parameters = http_method
+        parameters, session, flash, http_method = args
       end
 
       response.recycle_cached_body!
+
       parameters ||= {}
       if _default_version.present? && parameters[:version].blank? && parameters['version'].blank?
         parameters[:version] = _default_version
       end
+
       super
     end
 

--- a/spec/integration/rspec_spec.rb
+++ b/spec/integration/rspec_spec.rb
@@ -26,4 +26,18 @@ describe TestController, 'rspec integration', :integration => true, :target => '
       response.should have_exposed(:echo => "ping")
     end
   end
+
+  describe 'specifying a prefixed version' do
+    after do
+      response.should have_exposed(:echo => "ping")
+    end
+
+    it "gets the correct path when specifying a version of `2`" do
+      get :echo, :echo => "ping", :version => 2
+    end
+
+    it "gets the correct path when specifying a version of `v2`" do
+      get :echo, :echo => "ping", :version => 'v2'
+    end
+  end
 end

--- a/spec/support/controller.rb
+++ b/spec/support/controller.rb
@@ -3,6 +3,9 @@ TestRouter.draw do
   get  'echo', :to => 'test#echo'
   put  'echo', :to => 'test#echo'
   post 'echo', :to => 'test#echo'
+  api :version => 2, :allow_prefix => 'v' do
+    get 'a', :to => 'test#echo'
+  end
   # Actual mockable endpoints
   get 'exception',        :to => 'test#demo_exception'
   get 'test_data',        :to => 'test#test_data'
@@ -15,19 +18,19 @@ TestRouter.finalize!
 
 class TestController < RocketPants::Base
   include TestRouter.url_helpers
-  
+
   ErrorOfDoom = Class.new(StandardError)
   YetAnotherError = Class.new(ErrorOfDoom)
-  
+
   version 1..2
-  
+
   def self.test_data
   end
 
   def self.test_options
     {}
   end
-  
+
   def self.test_error
     NotImplementedError
   end
@@ -35,11 +38,11 @@ class TestController < RocketPants::Base
   def echo
     expose :echo => params[:echo]
   end
-  
+
   def demo_exception
     error! :throttled
   end
-  
+
   def test_data
     expose self.class.test_data, self.class.test_options
   end
@@ -51,7 +54,7 @@ class TestController < RocketPants::Base
   def test_render_json
     render_json self.class.test_data, self.class.test_options
   end
-  
+
   def test_error
     raise self.class.test_error
   end
@@ -64,5 +67,5 @@ class TestController < RocketPants::Base
     error! :throtted
     exposes :finished => true
   end
-  
+
 end

--- a/spec/support/controller.rb
+++ b/spec/support/controller.rb
@@ -1,11 +1,19 @@
 TestRouter = ActionDispatch::Routing::RouteSet.new
 TestRouter.draw do
-  get  'echo', :to => 'test#echo'
-  put  'echo', :to => 'test#echo'
-  post 'echo', :to => 'test#echo'
-  api :version => 2, :allow_prefix => 'v' do
-    get 'a', :to => 'test#echo'
+  api :version => 1 do
+    get  'echo', :to => 'test#echo'
+    put  'echo', :to => 'test#echo'
+    post 'echo', :to => 'test#echo'
   end
+
+  api :version => 2 do
+    get 'echo', :to => 'test#echo'
+  end
+
+  api :version => 2, :allow_prefix => 'v' do
+    get 'echo', :to => 'test#echo'
+  end
+
   # Actual mockable endpoints
   get 'exception',        :to => 'test#demo_exception'
   get 'test_data',        :to => 'test#test_data'


### PR DESCRIPTION
I've got a failing spec, but I'm struggling with the fix.

I can see that parameter defaults aren't getting passed through to the controller, and thus the prefix removal stuff isn't working.

I don't understand how it can actually work with Rails, but fail for a spec yet.

I've also cleaned up the rspec `have_exposed` error messages. They were a bit funky, and now they make a bit more sense.
