### PR TITLE
Fix TestHelper not working when no parameters are given

### DIFF
--- a/lib/rocket_pants/test_helper.rb
+++ b/lib/rocket_pants/test_helper.rb
@@ -77,7 +77,7 @@ module RocketPants
     # Like process, but automatically adds the api version.
     def process(action, http_method = 'GET', *args)
       # Rails 4 changes the method signature. In rails 3, http_method is actually
-      # the paramters.
+      # the parameters.
       if http_method.kind_of?(String)
         parameters, session, flash = args
       else
@@ -89,7 +89,7 @@ module RocketPants
       if _default_version.present? && parameters[:version].blank? && parameters['version'].blank?
         parameters[:version] = _default_version
       end
-      super
+      super action, parameters, *args
     end
 
     def normalise_value(value)

--- a/spec/integration/rspec_spec.rb
+++ b/spec/integration/rspec_spec.rb
@@ -20,10 +20,17 @@ describe TestController, 'rspec integration', :integration => true, :target => '
   end
 
   describe 'should have_exposed' do
-    it "allows you to asset what should have been exposed by an action" do
-      get :echo, :echo => "ping"
-
-      response.should have_exposed(:echo => "ping")
+    context "given a request with parameters" do
+      it "allows you to asset what should have been exposed by an action" do
+        get :echo, :echo => "ping"
+        response.should have_exposed(:echo => "ping")
+      end
+    end
+    context "given a request without parameters" do
+      it "allows you to asset what should have been exposed by an action" do
+        get :test_data
+        request.params.should include(:version)
+      end
     end
   end
 end


### PR DESCRIPTION
I checked out the master with the recent @keithpitt fix to the TestHelper. Everything worked fine expect for requests without parameters, typically, my "get :index" request.

This comes from the fact that when no parameters are given, we set the parameters variable as an empty hash so It loose it's reference to the http_method variable.

Explicitly passing arguments prevent this issue while avoiding tweaking too much the process method.

Tested against rails 3.2.12 and 4.0.0.beta1
