### PR TITLE
SerializerWrapper doesnt call serializable_hash with options

### DIFF
--- a/lib/rocket_pants/controller/respondable.rb
+++ b/lib/rocket_pants/controller/respondable.rb
@@ -7,7 +7,7 @@ module RocketPants
       def serializable_hash(options = {})
         instance = serializer.new(object, options)
         if instance.respond_to?(:serializable_hash)
-          instance.serializable_hash
+          instance.serializable_hash options
         else
           instance.as_json options
         end


### PR DESCRIPTION
SerializerWrapper should call the serializer's serializable_hash with options
the same way the code for regular objects in normalise_object does
