### PR TITLE
Add named exception notifier for Honeybadger

### DIFF
--- a/lib/rocket_pants/base.rb
+++ b/lib/rocket_pants/base.rb
@@ -40,6 +40,15 @@ module RocketPants
     rescue LoadError => e
     end
 
+    # If possible, include Honeybadger methods in the Rails controller
+    begin
+      require 'honeybadger'
+      require 'honeybadger/rails/controller_methods'
+      MODULES << Honeybadger::Rails::ControllerMethods
+    rescue LoadError => e
+    end
+
+
     MODULES.each do |mixin|
       include mixin
     end

--- a/lib/rocket_pants/controller/rescuable.rb
+++ b/lib/rocket_pants/controller/rescuable.rb
@@ -16,6 +16,11 @@ module RocketPants
         unless c.send(:airbrake_local_request?)
           c.error_identifier = Airbrake.notify(e, c.send(:airbrake_request_data))
         end
+      },
+      :honeybadger => lambda { |controller, exception, request|
+        if controller.respond_to?(:notify_honeybadger, true)
+          controller.send(:notify_honeybadger, exception)
+        end
       }
     }
 


### PR DESCRIPTION
This adds a named exception notifier callback for `:honeybadger` and also adds a test that a custom exception notifier callback gets called.
