### PR TITLE
removed hashie version dependency

### DIFF
--- a/rocket_pants.gemspec
+++ b/rocket_pants.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionpack', '>= 3.0', '< 5.0'
   s.add_dependency 'railties',   '>= 3.0', '< 5.0'
   s.add_dependency 'will_paginate', '~> 3.0'
-  s.add_dependency 'hashie',        '~> 1.0'
+  s.add_dependency 'hashie'
   s.add_dependency 'api_smith'
   s.add_dependency 'moneta'
   s.add_development_dependency 'rspec',       '~> 2.4'


### PR DESCRIPTION
it seems like rocket_pants and omniauth can not live together in peace because currently rocket_pants requires hashie (~> 1.0) and omniauth hashie (2.0.5)
removed the version dependency, and everything keeps working as it should (specs are green)

should (probably) be safe...
