### PR TITLE
Remove deprecation warning due to parameter change in ```process```.

### DIFF
--- a/lib/rocket_pants/test_helper.rb
+++ b/lib/rocket_pants/test_helper.rb
@@ -79,7 +79,7 @@ module RocketPants
       # Rails 4 changes the method signature. In rails 3, http_method is actually
       # the parameters.
       if http_method.kind_of?(String)
-        parameters, session, flash = args
+        parameters = args.shift
       else
         rails3_method_signature = true
         parameters = http_method

--- a/spec/integration/rspec_spec.rb
+++ b/spec/integration/rspec_spec.rb
@@ -20,17 +20,34 @@ describe TestController, 'rspec integration', :integration => true, :target => '
   end
 
   describe 'should have_exposed' do
+
     context "given a request with parameters" do
       it "allows you to asset what should have been exposed by an action" do
         get :echo, :echo => "ping"
         response.should have_exposed(:echo => "ping")
       end
     end
+
     context "given a request without parameters" do
       it "allows you to asset what should have been exposed by an action" do
         get :test_data
         request.params.should include(:version)
       end
     end
+
+    context "given a request with session" do
+      it "allows you to asset what should have been exposed by an action" do
+        get :echo_session, nil, { :echo => "ping" }, nil
+        response.should have_exposed(:echo => "ping")
+      end
+    end
+
+    context "given a request with flash" do
+      it "allows you to asset what should have been exposed by an action" do
+        get :echo_flash, nil, nil, { :echo => "ping" }
+        response.should have_exposed(:echo => "ping")
+      end
+    end
+
   end
 end

--- a/spec/support/controller.rb
+++ b/spec/support/controller.rb
@@ -3,6 +3,8 @@ TestRouter.draw do
   get  'echo', :to => 'test#echo'
   put  'echo', :to => 'test#echo'
   post 'echo', :to => 'test#echo'
+  get  'echo_session', :to => 'test#echo_session'
+  get  'echo_flash', :to => 'test#echo_flash'
   # Actual mockable endpoints
   get 'exception',        :to => 'test#demo_exception'
   get 'test_data',        :to => 'test#test_data'
@@ -34,6 +36,14 @@ class TestController < RocketPants::Base
 
   def echo
     expose :echo => params[:echo]
+  end
+  
+  def echo_session
+    expose :echo => session[:echo]
+  end
+
+  def echo_flash
+    expose :echo => request.flash[:echo]
   end
   
   def demo_exception


### PR DESCRIPTION
Since rails 4 the method signature of `process` was changed. This is reflected in current master when it comes to using the correct parameters.

But on the call to `super` the old style is used that generates alot of deprecation warnings from rails when testing our application.

Thanks
Jörg
