### PR TITLE
Fix url_for when there is a version prefix.

### DIFF
--- a/lib/rocket_pants/controller/url_for.rb
+++ b/lib/rocket_pants/controller/url_for.rb
@@ -3,7 +3,7 @@ module RocketPants
     
     def url_options
       options = super
-      options = options.merge(:version => version) if version.present?
+      options = options.merge(:version => params[:version]) if version.present?
       options
     end
     


### PR DESCRIPTION
url_for() requires a whole version component instead of an extracted version number part as :version parameter.

Currently there seems to be no test/spec for this, so I'm only submitting the fix.
