### PR TITLE
Remove root and instance_options for active model serializers 1.0.x compatability

### DIFF
--- a/lib/rocket_pants/rspec_matchers.rb
+++ b/lib/rocket_pants/rspec_matchers.rb
@@ -10,11 +10,14 @@ module RocketPants
       end
     end
 
+    KEYS_TO_DELETE = %w(url root instance_options).freeze
     def self.normalise_urls(object)
       if object.is_a?(Array)
-        object.each { |o| o['url'] = nil }
+        object.each do |o|
+          KEYS_TO_DELETE.each { |key| o[key] = nil }
+        end
       elsif object.is_a?(Hash) || (defined?(APISmith::Smash) && object.is_a?(APISmith::Smash))
-        object['url'] = nil
+        KEYS_TO_DELETE.each  { |key| object[key] = nil }
       end
       object
     end


### PR DESCRIPTION
Very sorry this has no specs :disappointed: 
With the new https://github.com/rails-api/active_model_serializers version was failing with 

``` ruby
       Diff: 

       @@ -1,6 +1,6 @@
       -"instance_options" => {},
       +"instance_options" => {"url_options"=>{"host"=>"test.host", "port"=>nil, "protocol"=>"http://", "_recall"=>{"version"=>"1", "controller"=>"...", "action"=>"..."}, "version"=>"1"}, "root"=>false, "singular"=>true},
        "object" => {"id"=>1, ...},
       -"root" => nil,
       +"root" => false,
        "scope" => nil,
        "url" => nil,
```

There is probably a more elegant way of doing this.
