### PR TITLE
Use new ActiveModel::SerializableResource

### DIFF
--- a/lib/rocket_pants/controller/respondable.rb
+++ b/lib/rocket_pants/controller/respondable.rb
@@ -5,14 +5,17 @@ module RocketPants
     SerializerWrapper = Struct.new(:serializer, :object) do
 
       def serializable_hash(options = {})
-        instance = serializer.new(object, options)
-        if instance.respond_to?(:serializable_hash)
-          instance.serializable_hash
+        if Object.const_defined?('ActiveModel::SerializableResource')
+          ActiveModel::SerializableResource.new(object, options.merge(serializer: serializer)).serializable_hash
         else
-          instance.as_json options
+          instance = serializer.new(object, options)
+          if instance.respond_to?(:serializable_hash)
+            instance.serializable_hash
+          else
+            instance.as_json options
+          end
         end
       end
-
     end
 
     def self.pagination_type(object)


### PR DESCRIPTION
`as_json` does not work with the newest version of https://github.com/rails-api/active_model_serializers and it is suggested that you use the `ActiveModel::SerializableResource` class.
