### PR TITLE
Make it compatible with kaminari 1.0

### DIFF
--- a/lib/rocket_pants/controller/respondable.rb
+++ b/lib/rocket_pants/controller/respondable.rb
@@ -18,7 +18,7 @@ module RocketPants
     def self.pagination_type(object)
       if object.respond_to?(:total_entries)
         :will_paginate
-      elsif object.respond_to?(:num_pages) && object.respond_to?(:current_page)
+      elsif object.respond_to?(:total_pages) && object.respond_to?(:current_page)
         :kaminari
       else
         nil
@@ -49,7 +49,7 @@ module RocketPants
           :pages    => collection.total_pages.try(:to_i)
         }
       when :kaminari
-        current, total, per_page = collection.current_page, collection.num_pages, collection.limit_value
+        current, total, per_page = collection.current_page, collection.total_pages, collection.limit_value
         {
           :current  => current,
           :previous => (current > 1 ? (current - 1) : nil),

--- a/rocket_pants.gemspec
+++ b/rocket_pants.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'activerecord', '>= 3.0', '< 5.0'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'reversible_data', '~> 1.0'
-  s.add_development_dependency 'kaminari'
+  s.add_development_dependency 'kaminari',    '>= 0.15'
 
   s.files        = Dir.glob("{lib}/**/*")
   s.require_path = 'lib'


### PR DESCRIPTION
In `kaminari 1.0` they removed method deprecated `num_pages` in favor of `total_pages`. Issue: #148 